### PR TITLE
Bump all versions in workflow to latest

### DIFF
--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -30,25 +30,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v5
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v6
         with:
-          go-version: '^1.21.1'
+          go-version: "^1.21.1"
       - name: Install Taskfile
-        uses: arduino/setup-task@v1
+        uses: arduino/setup-task@v2
         with:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 19.3
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
-          distribution: 'temurin'
-          java-version: '21'
+          distribution: "temurin"
+          java-version: "21"
       - name: Install dependencies
         run: npm i
       - name: Build
@@ -60,15 +60,14 @@ jobs:
           file $DEV_ENV_LOCATION
         shell: bash
         env:
-          DEV_ENV_FILE : ${{secrets.GOOGLE_SEARCH_AUTH_FILE}}
+          DEV_ENV_FILE: ${{secrets.GOOGLE_SEARCH_AUTH_FILE}}
           DEV_ENV_LOCATION: ${{secrets.GOOGLE_SEARCH_AUTH_LOCATION}}
 
-
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v4
         with:
           # Upload entire repository
-          path: 'dist/'
+          path: "dist/"
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v3
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
It's been a long time since this has been updated. There's a reasonable chance this fails if there have been breaking changes in each of the major versions but I'm just going to ship and see what happens and then fix it if it's still broken